### PR TITLE
Use strict generator types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4717,9 +4717,9 @@
       }
     },
     "typescript": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.1.tgz",
-      "integrity": "sha512-64HkdiRv1yYZsSe4xC1WVgamNigVYjlssIoaH2HcZF0+ijsk5YK2g0G34w9wJkze8+5ow4STd22AynfO6ZYYLw==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.2.tgz",
+      "integrity": "sha512-lmQ4L+J6mnu3xweP8+rOrUwzmN+MRAj7TgtJtDaXE5PMyX2kCrklhg3rvOsOIfNeAWMQWO2F1GPc1kMD2vLAfw==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "jasmine": "^3.4.0",
     "jest": "^24.8.0",
     "ts-jest": "^24.0.2",
-    "typescript": "^3.5.1"
+    "typescript": "^3.6.2"
   },
   "jest": {
     "preset": "ts-jest",

--- a/src/ByteStreamParser.ts
+++ b/src/ByteStreamParser.ts
@@ -4,14 +4,6 @@ export interface ArrayBufferViewConstructor<T extends ArrayBufferView = ArrayBuf
     readonly BYTES_PER_ELEMENT?: number;
 }
 
-export interface ByteStreamParserIterator<O, I extends ArrayBufferView = Uint8Array>
-    extends Iterator<number, O, I> {
-}
-
-export interface ByteStreamParserGenerator<O, I extends ArrayBufferView = Uint8Array>
-    extends Generator<number, O, I> {
-}
-
 /**
  * @param <O> The type of output chunks.
  * @param <I> The type of input byte chunks for the parser. Defaults to {@code Uint8Array}.
@@ -45,7 +37,7 @@ export abstract class ByteStreamParser<O, I extends ArrayBufferView = Uint8Array
         this._iterator.return();
     }
 
-    protected abstract parse_(): ByteStreamParserIterator<O, I>;
+    protected abstract parse_(): Iterator<number, O, I>;
 
     private _consume(chunk: Uint8Array) {
         if (chunk.byteLength === 0) {

--- a/test/Chunker.spec.ts
+++ b/test/Chunker.spec.ts
@@ -102,7 +102,7 @@ describe('3-byte chunker', () => {
         chunker.transform(new Uint8Array([1, 2, 3, 4, 5, 6]));
         expect(controller.enqueue).toHaveBeenCalledTimes(2);
         expect(controller.enqueue).toHaveBeenCalledWith(new Uint8Array([1, 2, 3]));
-        expect(controller.enqueue).toHaveBeenCalledWith(new Uint8Array([4, 5, 6]));
+        expect(controller.enqueue).toHaveBeenLastCalledWith(new Uint8Array([4, 5, 6]));
     });
 
     it('handles inputs with different lengths', () => {
@@ -111,7 +111,7 @@ describe('3-byte chunker', () => {
         chunker.transform(new Uint8Array([3, 4, 5, 6, 7]));
         expect(controller.enqueue).toHaveBeenCalledTimes(2);
         expect(controller.enqueue).toHaveBeenCalledWith(new Uint8Array([1, 2, 3]));
-        expect(controller.enqueue).toHaveBeenCalledWith(new Uint8Array([4, 5, 6]));
+        expect(controller.enqueue).toHaveBeenLastCalledWith(new Uint8Array([4, 5, 6]));
         chunker.transform(new Uint8Array([8, 9, 10]));
         expect(controller.enqueue).toHaveBeenCalledTimes(3);
         expect(controller.enqueue).toHaveBeenLastCalledWith(new Uint8Array([7, 8, 9]));

--- a/test/Chunker.spec.ts
+++ b/test/Chunker.spec.ts
@@ -1,4 +1,4 @@
-import {ByteStreamParser, ByteStreamParserGenerator, ByteStreamParserIterator} from "../src/ByteStreamParser";
+import {ByteStreamParser} from "../src/ByteStreamParser";
 import {MockTransformController, Spied, spyOnMethods} from "./Mocks";
 
 class Chunker extends ByteStreamParser<Uint8Array> {
@@ -7,11 +7,11 @@ class Chunker extends ByteStreamParser<Uint8Array> {
         super(Uint8Array);
     }
 
-    protected parse_(): ByteStreamParserIterator<Uint8Array> {
+    protected parse_(): Iterator<number, Uint8Array, Uint8Array> {
         return this.parseGenerator_();
     }
 
-    protected* parseGenerator_(): ByteStreamParserGenerator<Uint8Array> {
+    protected* parseGenerator_(): Generator<number, Uint8Array, Uint8Array> {
         return (yield this.chunkSize);
     }
 
@@ -19,7 +19,7 @@ class Chunker extends ByteStreamParser<Uint8Array> {
 
 class ChunkerWithoutReturn extends Chunker {
 
-    protected parse_(): ByteStreamParserIterator<Uint8Array> {
+    protected parse_() {
         const iterator = this.parseGenerator_();
         const iteratorWithoutReturn: Iterator<number, Uint8Array, Uint8Array> = {
             next: iterator.next.bind(iterator),
@@ -38,7 +38,7 @@ class ChunkerWithFinally extends Chunker {
         super(chunkSize);
     }
 
-    protected* parse_(): ByteStreamParserGenerator<Uint8Array> {
+    protected* parse_() {
         let result: Uint8Array | undefined;
         try {
             result = yield* super.parseGenerator_();

--- a/test/Packetizer.spec.ts
+++ b/test/Packetizer.spec.ts
@@ -1,0 +1,74 @@
+import {ByteStreamParser, ByteStreamParserGenerator} from "../src/ByteStreamParser";
+import {MockTransformController, Spied, spyOnMethods} from "./Mocks";
+
+interface Packet {
+    size: number;
+    data: Uint8Array;
+}
+
+class Packetizer extends ByteStreamParser<Packet> {
+
+    constructor() {
+        super(Uint8Array);
+    }
+
+    protected* parse_(): ByteStreamParserGenerator<Packet> {
+        const size = (yield 1)[0];
+        const data = yield size;
+        return {size, data};
+    }
+
+}
+
+describe('packetizer', () => {
+    let controller!: Spied<MockTransformController<Packet>>;
+    let packetizer!: Packetizer;
+    beforeEach(() => {
+        controller = spyOnMethods(new MockTransformController(), ['enqueue', 'error', 'terminate']);
+        packetizer = new Packetizer();
+        packetizer.start(controller);
+    });
+
+    it('handles empty packet', () => {
+        packetizer.transform(new Uint8Array([0]));
+        expect(controller.enqueue).toHaveBeenCalledTimes(1);
+        expect(controller.enqueue).toHaveBeenLastCalledWith({
+            size: 0,
+            data: new Uint8Array([])
+        });
+        expect(controller.error).not.toHaveBeenCalled();
+        expect(controller.terminate).not.toHaveBeenCalled();
+    });
+
+    it('handles single byte packets', () => {
+        packetizer.transform(new Uint8Array([1]));
+        expect(controller.enqueue).not.toHaveBeenCalled();
+        packetizer.transform(new Uint8Array([42]));
+        expect(controller.enqueue).toHaveBeenCalledTimes(1);
+        expect(controller.enqueue).toHaveBeenLastCalledWith({
+            size: 1,
+            data: new Uint8Array([42])
+        });
+        expect(controller.error).not.toHaveBeenCalled();
+        expect(controller.terminate).not.toHaveBeenCalled();
+    });
+
+    it('handles multiple packets with different sizes', () => {
+        packetizer.transform(new Uint8Array([1, 42]));
+        expect(controller.enqueue).toHaveBeenCalledTimes(1);
+        expect(controller.enqueue).toHaveBeenLastCalledWith({
+            size: 1,
+            data: new Uint8Array([42])
+        });
+        packetizer.transform(new Uint8Array([3, 101]));
+        expect(controller.enqueue).toHaveBeenCalledTimes(1);
+        packetizer.transform(new Uint8Array([102, 103]));
+        expect(controller.enqueue).toHaveBeenCalledTimes(2);
+        expect(controller.enqueue).toHaveBeenLastCalledWith({
+            size: 3,
+            data: new Uint8Array([101, 102, 103])
+        });
+        expect(controller.error).not.toHaveBeenCalled();
+        expect(controller.terminate).not.toHaveBeenCalled();
+    });
+});

--- a/test/Packetizer.spec.ts
+++ b/test/Packetizer.spec.ts
@@ -1,4 +1,4 @@
-import {ByteStreamParser, ByteStreamParserGenerator} from "../src/ByteStreamParser";
+import {ByteStreamParser} from "../src/ByteStreamParser";
 import {MockTransformController, Spied, spyOnMethods} from "./Mocks";
 
 interface Packet {
@@ -12,7 +12,7 @@ class Packetizer extends ByteStreamParser<Packet> {
         super(Uint8Array);
     }
 
-    protected* parse_(): ByteStreamParserGenerator<Packet> {
+    protected* parse_(): Generator<number, Packet, Uint8Array> {
         const size = (yield 1)[0];
         const data = yield size;
         return {size, data};

--- a/test/Thrower.spec.ts
+++ b/test/Thrower.spec.ts
@@ -1,4 +1,4 @@
-import {ByteStreamParser, ByteStreamParserIterableIterator} from "../src/ByteStreamParser";
+import {ByteStreamParser, ByteStreamParserGenerator} from "../src/ByteStreamParser";
 import {MockTransformController, Spied, spyOnMethods} from "./Mocks";
 
 class Thrower extends ByteStreamParser<never> {
@@ -8,7 +8,7 @@ class Thrower extends ByteStreamParser<never> {
         super(Uint8Array);
     }
 
-    protected* parse_(): ByteStreamParserIterableIterator<never> {
+    protected* parse_(): ByteStreamParserGenerator<never> {
         yield this.readAmount;
         throw this.error;
     }

--- a/test/Thrower.spec.ts
+++ b/test/Thrower.spec.ts
@@ -1,4 +1,4 @@
-import {ByteStreamParser, ByteStreamParserGenerator} from "../src/ByteStreamParser";
+import {ByteStreamParser} from "../src/ByteStreamParser";
 import {MockTransformController, Spied, spyOnMethods} from "./Mocks";
 
 class Thrower extends ByteStreamParser<never> {
@@ -8,7 +8,7 @@ class Thrower extends ByteStreamParser<never> {
         super(Uint8Array);
     }
 
-    protected* parse_(): ByteStreamParserGenerator<never> {
+    protected* parse_(): Generator<number, never, Uint8Array> {
         yield this.readAmount;
         throw this.error;
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,8 @@
     "lib": [
       "dom",
       "es5",
-      "es2015.iterable"
+      "es2015.iterable",
+      "es2015.generator"
     ]
   }
 }


### PR DESCRIPTION
[TypeScript 3.6](https://devblogs.microsoft.com/typescript/announcing-typescript-3-6/) introduces stricter checking for iterators and generator functions. We can use this to better describe the return value of `ByteStreamParser.parser_`, and remove some (now unnecessary) type casts in the implementation.